### PR TITLE
avoid busy waiting

### DIFF
--- a/threads.c
+++ b/threads.c
@@ -77,6 +77,8 @@ int kthread_server_fn(void *t)
     while(!kthread_should_stop()) {
         error = kernel_accept(socket, &pworkersocket, O_NONBLOCK);
 	if (error == -EAGAIN) {
+	    set_current_state(TASK_RUNNING);
+	    schedule();
 	    continue;
 	}
         if (error < 0) {


### PR DESCRIPTION
If kernel is 3.12.28-4 in SLES 12 . it will be occur the busy waiting. 
add two lines code so that  can be schedule the task alive with in listen socket.. 